### PR TITLE
fix: correct module name in fixup-dist

### DIFF
--- a/fixup-dist.js
+++ b/fixup-dist.js
@@ -73,7 +73,7 @@ function fixupPluginsImports(file) {
 function fixupPluginsModuleAugmentation(file) {
     editFile(file, (data) => {
         const regex = /declare module "\.\.\/\.\.\/types.js"/g;
-        return data.replaceAll(regex, 'declare module "yet-another-react-lightbox"');
+        return data.replaceAll(regex, 'declare module "@danielmoraes/yet-another-react-lightbox"');
     });
 }
 


### PR DESCRIPTION
Correct module name to import plugins and register their props to the Lightbox component.

<!-- Thank you so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed the 'Sending a Pull Request' section of the [contributing guide](https://github.com/igordanchenko/yet-another-react-lightbox/blob/main/CONTRIBUTING.md#sending-a-pull-request)
