### PR TITLE
fix: expect close button to be in the document

### DIFF
--- a/test/unit/plugins/Inline.spec.ts
+++ b/test/unit/plugins/Inline.spec.ts
@@ -12,7 +12,7 @@ function renderLightbox(props?: LightboxExternalProps) {
 
 function testMainScenario() {
     expect(screen.queryByRole("presentation")).toBeInTheDocument();
-    expect(screen.queryByLabelText("Close")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Close")).toBeInTheDocument();
     expect(screen.queryByLabelText("Previous")).toBeInTheDocument();
     expect(screen.queryByLabelText("Next")).toBeInTheDocument();
 }


### PR DESCRIPTION
Take into account change made to Toolbar in e475cd6b, where the close button is rendered along the container.

<!-- Thank you so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed the 'Sending a Pull Request' section of the [contributing guide](https://github.com/igordanchenko/yet-another-react-lightbox/blob/main/CONTRIBUTING.md#sending-a-pull-request)
